### PR TITLE
Update to non-release candidate driver version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ val neo4jVersion = "3.5.9"
 val testcontainersVersion = "1.12.2"
 val kotlinVersion = plugins.getPlugin(KotlinPluginWrapper::class.java).kotlinPluginVersion
 plugins {
-    kotlin("jvm") version "1.3.50"
+    kotlin("jvm") version "1.3.70"
 }
 
 group = "net.emdal.tanK"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val spekVersion = "2.0.7"
-val neo4jJavaDriverVersion = "4.0.0-beta01"
+val neo4jJavaDriverVersion = "4.0.0"
 val junitVersion = "5.5.2"
 val neo4jVersion = "3.5.9"
 val testcontainersVersion = "1.12.2"


### PR DESCRIPTION
Update to `org.neo4j.driver:neo4j-java-driver:4.0.0`